### PR TITLE
Cross-platform start with SDL2

### DIFF
--- a/01Line/CMakeLists.txt
+++ b/01Line/CMakeLists.txt
@@ -19,7 +19,13 @@ set(HEADER_FILES
     WindowClass.h
 )
 
-add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+if(WIN32)
+    add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+else()
+    find_package(SDL2 REQUIRED)
+    add_executable(${PROJECT_NAME} wWinMain.cpp ${HEADER_FILES})
+    target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2)
+endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 20
@@ -33,9 +39,14 @@ else()
     target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -pedantic -Werror)
 endif()
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE _UNICODE)
+if(WIN32)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE UNICODE _UNICODE)
+endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT WIN32)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
+endif()
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME}

--- a/01Line/pch.h
+++ b/01Line/pch.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <thread>
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define OEMRESOURCE
 
@@ -20,6 +21,7 @@
 #include <dwmapi.h>
 #include <d2d1.h>
 #include <timeapi.h>
+#endif
 
 template<class T>
 void SafeRelease(T** ppT)

--- a/01Line/wWinMain.cpp
+++ b/01Line/wWinMain.cpp
@@ -1,18 +1,64 @@
+#ifdef _WIN32
 #include "Application.h"
 
 int APIENTRY wWinMain(_In_ [[maybe_unused]] HINSTANCE hInstance, _In_opt_ [[maybe_unused]] HINSTANCE hPrevInstance, _In_ [[maybe_unused]] LPWSTR lpCmdLine, _In_ int nCmdShow)
 {
-	MSG msg{};
-	{
-		gm::Application application{ nCmdShow };
+        MSG msg{};
+        {
+                gm::Application application{ nCmdShow };
 
-		while (GetMessage(&msg, nullptr, 0, 0))
-		{
-			if (msg.message == WM_DWMCOMPOSITIONCHANGED)
-				application.GetWindow()->InvalidateRectangle();
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
-	}
-	return (int)msg.wParam;
+                while (GetMessage(&msg, nullptr, 0, 0))
+                {
+                        if (msg.message == WM_DWMCOMPOSITIONCHANGED)
+                                application.GetWindow()->InvalidateRectangle();
+                        TranslateMessage(&msg);
+                        DispatchMessage(&msg);
+                }
+        }
+        return (int)msg.wParam;
 }
+#else
+#include <SDL.h>
+
+int main(int argc, char** argv)
+{
+        if (SDL_Init(SDL_INIT_VIDEO) != 0)
+                return 1;
+
+        SDL_Window* window = SDL_CreateWindow(
+                "GameMath 01: Line",
+                SDL_WINDOWPOS_CENTERED,
+                SDL_WINDOWPOS_CENTERED,
+                1280,
+                960,
+                0);
+
+        if (!window)
+        {
+                SDL_Quit();
+                return 1;
+        }
+
+        SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, 0);
+        SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+        SDL_RenderClear(renderer);
+        SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
+        SDL_RenderDrawLine(renderer, 320, 240, 960, 720);
+        SDL_RenderPresent(renderer);
+
+        SDL_Event event;
+        bool running = true;
+        while (running)
+        {
+                while (SDL_PollEvent(&event))
+                        if (event.type == SDL_QUIT)
+                                running = false;
+                SDL_Delay(16);
+        }
+
+        SDL_DestroyRenderer(renderer);
+        SDL_DestroyWindow(window);
+        SDL_Quit();
+        return 0;
+}
+#endif


### PR DESCRIPTION
## Summary
- add `#ifdef _WIN32` guard in precompiled header
- use SDL2 when not building on Windows
- conditionally build 01Line with SDL2

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_684f25d141f4832f8e9d4b8c35756e4f