### PR TITLE
Fix unused parameters in cross-platform main

### DIFF
--- a/01Line/wWinMain.cpp
+++ b/01Line/wWinMain.cpp
@@ -20,7 +20,7 @@ int APIENTRY wWinMain(_In_ [[maybe_unused]] HINSTANCE hInstance, _In_opt_ [[mayb
 #else
 #include <SDL.h>
 
-int main(int argc, char** argv)
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
 {
         if (SDL_Init(SDL_INIT_VIDEO) != 0)
                 return 1;


### PR DESCRIPTION
## Summary
- mark `argc` and `argv` parameters as `[[maybe_unused]]` for non-Windows build

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "SDL2")*

------
https://chatgpt.com/codex/tasks/task_e_684f2b9e4448832fad60862b4835b28d