### PR TITLE
Fix Linux build failure by guarding Windows headers

### DIFF
--- a/03ObjectToWorld/pch.h
+++ b/03ObjectToWorld/pch.h
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <thread>
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #define OEMRESOURCE
 
@@ -20,6 +21,7 @@
 #include <dwmapi.h>
 #include <d2d1.h>
 #include <timeapi.h>
+#endif
 
 template<class T>
 void SafeRelease(T** ppT)


### PR DESCRIPTION
## Summary
- guard Windows-specific headers in `03ObjectToWorld/pch.h`

## Testing
- `cmake ..` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_684f2fffe9d4832faff6cb37335fd794